### PR TITLE
Fix code scanning alert no. 3: Disabling certificate validation

### DIFF
--- a/src/env/node/fetch.ts
+++ b/src/env/node/fetch.ts
@@ -49,12 +49,12 @@ export async function wrapForForcedInsecureSSL<T>(
 ): Promise<T> {
 	if (ignoreSSLErrors !== 'force') return fetchFn();
 
-	const previousRejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
-	process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+	const https = require('https');
+	const agent = new https.Agent({ rejectUnauthorized: false });
 
 	try {
-		return await fetchFn();
+		return await fetchFn({ agent });
 	} finally {
-		process.env.NODE_TLS_REJECT_UNAUTHORIZED = previousRejectUnauthorized;
+		// No need to restore global state
 	}
 }


### PR DESCRIPTION
Fixes [https://github.com/guruh46/vscode-gitlens/security/code-scanning/3](https://github.com/guruh46/vscode-gitlens/security/code-scanning/3)

To fix the problem, we should avoid globally disabling certificate validation by setting `process.env.NODE_TLS_REJECT_UNAUTHORIZED` to '0'. Instead, we can use a more targeted approach by configuring the HTTPS agent for the specific request that needs to ignore SSL errors. This way, we limit the scope of the insecure configuration to only the necessary requests.

We will modify the `wrapForForcedInsecureSSL` function to use a custom HTTPS agent with `rejectUnauthorized` set to `false` for the specific fetch function call, rather than modifying the global environment variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
