### PR TITLE
Fix code scanning alert no. 10: Incomplete string escaping or encoding

### DIFF
--- a/src/system/commands.ts
+++ b/src/system/commands.ts
@@ -10,8 +10,7 @@ export function createMarkdownCommandLink<T>(command: Commands | TreeViewCommand
 	if (args == null) return `command:${command}`;
 
 	// Since we are using the command in a markdown link, we need to escape ()'s so they don't get interpreted as markdown
-	return `command:${command}?${encodeURIComponent(typeof args === 'string' ? args : JSON.stringify(args)).replace(
-		/([()])/g,
-		'\\$1',
-	)}`;
+	return `command:${command}?${encodeURIComponent(typeof args === 'string' ? args : JSON.stringify(args))
+		.replace(/\\/g, '\\\\')
+		.replace(/([()])/g, '\\$1')}`;
 }


### PR DESCRIPTION
Fixes [https://github.com/guruh46/vscode-gitlens/security/code-scanning/10](https://github.com/guruh46/vscode-gitlens/security/code-scanning/10)

To fix the problem, we need to ensure that backslashes are properly escaped in the input string. This can be achieved by adding an additional `replace` call to escape backslashes before escaping other characters. Specifically, we should replace backslashes with double backslashes before replacing parentheses.

The best way to fix the problem without changing existing functionality is to modify the `createMarkdownCommandLink` function to include an additional `replace` call for backslashes. This change should be made in the file `src/system/commands.ts` on lines 13-16.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
