### PR TITLE
Fix code scanning alert no. 9: Incomplete string escaping or encoding

### DIFF
--- a/src/git/remotes/bitbucket.ts
+++ b/src/git/remotes/bitbucket.ts
@@ -143,7 +143,7 @@ export class BitbucketRemote extends RemoteProvider {
 	}
 
 	protected override getUrlForComparison(base: string, compare: string, _notation: '..' | '...'): string {
-		return this.encodeUrl(`${this.baseUrl}/branches/compare/${base}%0D${compare}`).replace('%250D', '%0D');
+		return this.encodeUrl(`${this.baseUrl}/branches/compare/${base}%0D${compare}`).replace(/%250D/g, '%0D');
 	}
 
 	protected getUrlForFile(fileName: string, branch?: string, sha?: string, range?: Range): string {


### PR DESCRIPTION
Fixes [https://github.com/guruh46/vscode-gitlens/security/code-scanning/9](https://github.com/guruh46/vscode-gitlens/security/code-scanning/9)

To fix the problem, we need to ensure that all occurrences of `%250D` are replaced with `%0D`. This can be achieved by using a regular expression with the global flag (`g`) in the `replace` method. This change will ensure that every instance of `%250D` in the string is replaced, not just the first one.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
