### PR TITLE
Fix code scanning alert no. 8: Incomplete string escaping or encoding

### DIFF
--- a/src/git/remotes/bitbucket-server.ts
+++ b/src/git/remotes/bitbucket-server.ts
@@ -158,7 +158,7 @@ export class BitbucketServerRemote extends RemoteProvider {
 	}
 
 	protected override getUrlForComparison(base: string, compare: string, _notation: '..' | '...'): string {
-		return this.encodeUrl(`${this.baseUrl}/branches/compare/${base}%0D${compare}`).replace('%250D', '%0D');
+		return this.encodeUrl(`${this.baseUrl}/branches/compare/${base}%0D${compare}`).replace(/%250D/g, '%0D');
 	}
 
 	protected getUrlForFile(fileName: string, branch?: string, sha?: string, range?: Range): string {


### PR DESCRIPTION
Fixes [https://github.com/guruh46/vscode-gitlens/security/code-scanning/8](https://github.com/guruh46/vscode-gitlens/security/code-scanning/8)

To fix the problem, we need to ensure that all occurrences of '%250D' are replaced with '%0D'. This can be achieved by using a regular expression with the global flag (`g`). This will ensure that every instance of '%250D' in the string is replaced.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
