### PR TITLE
Fix code scanning alert no. 7: Incomplete string escaping or encoding

### DIFF
--- a/src/git/formatters/commitFormatter.ts
+++ b/src/git/formatters/commitFormatter.ts
@@ -758,12 +758,12 @@ export class CommitFormatter extends Formatter<GitCommit, CommitFormatOptions> {
 					pullRequest: { id: pr.id, url: pr.url },
 				})} "Open Pull Request \\#${pr.id}${
 					Container.instance.actionRunners.count('openPullRequest') === 1 ? ` on ${pr.provider.name}` : '...'
-				}\n${GlyphChars.Dash.repeat(2)}\n${escapeMarkdown(pr.title).replace(/"/g, '\\"')}\n${
+				}\n${GlyphChars.Dash.repeat(2)}\n${escapeMarkdown(pr.title).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}\n${
 					pr.state
 				}, ${pr.formatDateFromNow()}")`;
 
 				if (this._options.footnotes != null) {
-					const prTitle = escapeMarkdown(pr.title).replace(/"/g, '\\"').trim();
+					const prTitle = escapeMarkdown(pr.title).replace(/\\/g, '\\\\').replace(/"/g, '\\"').trim();
 
 					const index = this._options.footnotes.size + 1;
 					this._options.footnotes.set(


### PR DESCRIPTION
Fixes [https://github.com/guruh46/vscode-gitlens/security/code-scanning/7](https://github.com/guruh46/vscode-gitlens/security/code-scanning/7)

To fix the problem, we need to ensure that backslashes are properly escaped in addition to the existing escaping of double quotes. This can be achieved by adding a replacement for backslashes before the replacement for double quotes. We will use a regular expression with the global flag to ensure all occurrences are replaced.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
