### PR TITLE
Fix code scanning alert no. 6: Incomplete string escaping or encoding

### DIFF
--- a/src/git/formatters/commitFormatter.ts
+++ b/src/git/formatters/commitFormatter.ts
@@ -758,12 +758,12 @@ export class CommitFormatter extends Formatter<GitCommit, CommitFormatOptions> {
 					pullRequest: { id: pr.id, url: pr.url },
 				})} "Open Pull Request \\#${pr.id}${
 					Container.instance.actionRunners.count('openPullRequest') === 1 ? ` on ${pr.provider.name}` : '...'
-				}\n${GlyphChars.Dash.repeat(2)}\n${escapeMarkdown(pr.title).replace(/"/g, '\\"')}\n${
+				}\n${GlyphChars.Dash.repeat(2)}\n${escapeMarkdown(pr.title).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}\n${
 					pr.state
 				}, ${pr.formatDateFromNow()}")`;
 
 				if (this._options.footnotes != null) {
-					const prTitle = escapeMarkdown(pr.title).replace(/"/g, '\\"').trim();
+					const prTitle = escapeMarkdown(pr.title).replace(/\\/g, '\\\\').replace(/"/g, '\\"').trim();
 
 					const index = this._options.footnotes.size + 1;
 					this._options.footnotes.set(


### PR DESCRIPTION
Fixes [https://github.com/guruh46/vscode-gitlens/security/code-scanning/6](https://github.com/guruh46/vscode-gitlens/security/code-scanning/6)

To fix the problem, we need to ensure that backslashes are properly escaped in the `pr.title` after it has been processed by the `escapeMarkdown` function. This can be achieved by adding a `replace` method to escape backslashes before escaping double quotes.

- Modify the `replace` method to handle backslashes by adding a step to escape backslashes before escaping double quotes.
- Ensure that the changes are applied consistently in both places where `escapeMarkdown(pr.title).replace` is used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
