### PR TITLE
Fix code scanning alert no. 4: Incomplete string escaping or encoding

### DIFF
--- a/src/autolinks/autolinks.ts
+++ b/src/autolinks/autolinks.ts
@@ -470,7 +470,7 @@ export class Autolinks implements Disposable {
 										} else {
 											const issue = issueResult.value;
 											const issueTitle = escapeMarkdown(issue.title.trim());
-											const issueTitleQuoteEscaped = issueTitle.replace(/"/g, '\\"');
+											const issueTitleQuoteEscaped = issueTitle.replace(/(["\\])/g, '\\$1');
 
 											if (footnotes != null && !prs?.has(num)) {
 												footnoteIndex = footnotes.size + 1;


### PR DESCRIPTION
Fixes [https://github.com/guruh46/vscode-gitlens/security/code-scanning/4](https://github.com/guruh46/vscode-gitlens/security/code-scanning/4)

To fix the problem, we need to ensure that backslashes are also escaped in the `issueTitle`. This can be done by using a regular expression that handles both double quotes and backslashes. We will replace the current `issueTitle.replace(/"/g, '\\"')` with a more comprehensive regular expression that escapes both characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
