### PR TITLE
Fix code scanning alert no. 11: Disabling certificate validation

### DIFF
--- a/src/env/node/fetch.ts
+++ b/src/env/node/fetch.ts
@@ -50,7 +50,7 @@ export async function wrapForForcedInsecureSSL<T>(
 	if (ignoreSSLErrors !== 'force') return fetchFn();
 
 	const https = require('https');
-	const agent = new https.Agent({ rejectUnauthorized: false });
+	const agent = new https.Agent();
 
 	try {
 		return await fetchFn({ agent });


### PR DESCRIPTION
Fixes [https://github.com/guruh46/vscode-gitlens/security/code-scanning/11](https://github.com/guruh46/vscode-gitlens/security/code-scanning/11)

To fix the problem, we need to ensure that certificate validation is not disabled by setting `rejectUnauthorized` to `false`. Instead, we should allow the default behavior, which is to validate certificates. If there is a need to handle SSL errors, it should be done in a secure manner, possibly by logging the errors or providing a way to handle them without disabling validation.

The best way to fix this issue is to remove the line that sets `rejectUnauthorized: false` and ensure that the default behavior of validating certificates is maintained. This change should be made in the `wrapForForcedInsecureSSL` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
