### PR TITLE
Potential fix for code scanning alert no. 19: Incomplete string escaping or encoding

### DIFF
--- a/src/system/-webview/vscode.ts
+++ b/src/system/-webview/vscode.ts
@@ -147,7 +147,7 @@ export async function getHostExecutablePath(): Promise<string> {
 }
 
 export async function getHostEditorCommand(): Promise<string> {
-	const path = normalizePath(await getHostExecutablePath()).replace(/ /g, '\\ ');
+	const path = normalizePath(await getHostExecutablePath()).replace(/\\/g, '\\\\').replace(/ /g, '\\ ');
 	return `${path} --wait --reuse-window`;
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/vscode-gitlens/security/code-scanning/19](https://github.com/guruh46/vscode-gitlens/security/code-scanning/19)

To fix the problem, we need to ensure that all occurrences of spaces and backslashes in the path are properly escaped. This can be achieved by using a regular expression with the global flag to replace all spaces with escaped spaces (`\\ `) and to escape backslashes (`\\`). This will ensure that the path is correctly formatted for use in a command line context.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
