### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,13 +1,16 @@
 name: Unit tests
 
+permissions:
+    contents: read
+
 on:
     pull_request:
         branches: ['*']
         types:
-            - opened
-            - reopened
-            - synchronize
-            - ready_for_review
+           - opened
+           - reopened
+           - synchronize
+           - ready_for_review
 
 jobs:
     test:


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/vscode-gitlens/security/code-scanning/13](https://github.com/guruh46/vscode-gitlens/security/code-scanning/13)

To fix the issue, we will add a `permissions` block at the workflow level (root) to explicitly define the minimal permissions required. Since the workflow only checks out the repository and runs a local script, it likely only needs `contents: read` permissions. This ensures that the `GITHUB_TOKEN` is restricted to read-only access to the repository contents, reducing the risk of unintended write operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
