### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd-pre.yml
+++ b/.github/workflows/cd-pre.yml
@@ -51,6 +51,8 @@ jobs:
         needs: check
         runs-on: ubuntu-latest
         if: needs.check.outputs.status == 'changed'
+        permissions:
+            contents: read
         steps:
             - name: Checkout code
               uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/vscode-gitlens/security/code-scanning/12](https://github.com/guruh46/vscode-gitlens/security/code-scanning/12)

To fix the issue, we need to add a `permissions` block to the `publish` job. Based on the actions performed in the job, the minimal required permission is `contents: read`. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents, which is sufficient for the job's operations.

The changes will be made in the `.github/workflows/cd-pre.yml` file:
1. Add a `permissions` block under the `publish` job.
2. Set the permissions to `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
